### PR TITLE
Formatting changes on Scanner.py

### DIFF
--- a/Scanner.py
+++ b/Scanner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python #Using this shebang ensures Python can be found on each linux distributions.
 
 import nmap
 
@@ -8,37 +8,39 @@ print("Welcome, this is a simple nmap automation tool")
 print("<----------------------------------------------------->")
 
 ip_addr = input("Please enter the IP address you want to scan: ")
-print("The IP you entered is: ", ip_addr)
+print("The IP you entered is:", ip_addr) #Edited formatting
 type(ip_addr)
 
 resp = input("""\nPlease enter the type of scan you want to run
                 1)SYN ACK Scan
                 2)UDP Scan
-                3)Comprehensive Scan \n""")
-print("You have selected option: ", resp)
+                3)Comprehensive Scan
+                
+Enter your option: """) #Edited formatting
+print("You have selected option:", resp) #Edited formatting
 
 if resp == '1':
-    print("Nmap Version: ", scanner.nmap_version())
+    print("Nmap Version:", scanner.nmap_version()) #Edited formatting
     scanner.scan(ip_addr, '1-1024', '-v -sS')
     print(scanner.scaninfo())
-    print("Ip Status: ", scanner[ip_addr].state())
+    print("Ip Status:", scanner[ip_addr].state()) #Edited formatting
     print(scanner[ip_addr].all_protocols())
-    print("Open Ports: ", scanner[ip_addr]['tcp'].keys())
+    print("Open Ports:", scanner[ip_addr]['tcp'].keys()) #Edited formatting
 elif resp == '2':
-    print("Nmap Version: ", scanner.nmap_version())
+    print("Nmap Version:", scanner.nmap_version()) #Edited formatting
     scanner.scan(ip_addr, '1-1024', '-v -sU')
     print(scanner.scaninfo())
-    print("Ip Status: ", scanner[ip_addr].state())
+    print("Ip Status:", scanner[ip_addr].state()) #Edited formatting
     print(scanner[ip_addr].all_protocols())
-    print("Open Ports: ", scanner[ip_addr]['udp'].keys())
+    print("Open Ports:", scanner[ip_addr]['udp'].keys()) #Edited formatting
 elif resp == '3':
-    print("Nmap Version: ", scanner.nmap_version())
+    print("Nmap Version:", scanner.nmap_version()) #Edited formatting
     scanner.scan(ip_addr, '1-1024', '-v -sS -sV -sC -A -O')
     print(scanner.scaninfo())
-    print("Ip Status: ", scanner[ip_addr].state())
+    print("Ip Status:", scanner[ip_addr].state()) #Edited formatting
     print(scanner[ip_addr].all_protocols())
-    print("Open Ports: ", scanner[ip_addr]['tcp'].keys())
-elif resp >= '4':
+    print("Open Ports:", scanner[ip_addr]['tcp'].keys()) #Edited formatting
+else: #removed elif to catch more invalid options (e.g. negative numbers, strings)
     print("Please enter a valid option")
 
 


### PR DESCRIPTION
Changed how the code prints its results.

`randStr = "foo bar"`
`print("Value is ", randStr)`
produces [`Value is  foo bar`](https://imgur.com/tK3EG4r) (can't see it on github)

while

`randStr = "foo bar"`
`print("Value is", randStr)`
produces [`Value is foo bar`](https://imgur.com/YU1cOBs)

Notice that there is a double space on the former code between `is` and `foo`

Edited from `#!/usr/bin/python3` to `#!/usr/bin/env python` for compatibility

Replaced `elif resp >= '4':` with `else:` to catch negative numbers and strings